### PR TITLE
Updated links to new docs

### DIFF
--- a/components/Governance/Proposals.tsx
+++ b/components/Governance/Proposals.tsx
@@ -19,7 +19,7 @@ export const Proposals = () => {
       <Container
         label="Governance Proposals"
         description="Participate in governance of the DAO"
-        href="https://docs.inverse.finance/governance"
+        href="https://docs.inverse.finance/inverse-finance/governance"
       >
         <SkeletonBlob skeletonHeight={16} noOfLines={4} />
       </Container>
@@ -30,7 +30,7 @@ export const Proposals = () => {
     <Container
       label="Governance Proposals"
       description="Participate in governance of the DAO"
-      href="https://docs.inverse.finance/governance"
+      href="https://docs.inverse.finance/inverse-finance/governance"
     >
       <Stack w="full" spacing={1}>
         {proposals


### PR DESCRIPTION
Issue encountered: these links direct to "Page not found" within Gitbook. 
This was because when the docs were rebuilt, a new link schema was used. 
I propose updating the links to new ones to resolve this issue.
- Old Link: https://docs.inverse.finance/governance
- New link: https://docs.inverse.finance/inverse-finance/governance